### PR TITLE
Fix boot animation rotation problem when ro.sf.hwrotation is set to 9…

### DIFF
--- a/services/surfaceflinger/DisplayDevice.cpp
+++ b/services/surfaceflinger/DisplayDevice.cpp
@@ -392,7 +392,14 @@ void DisplayDevice::setProjection(int orientation,
     if (!frame.isValid()) {
         // the destination frame can be invalid if it has never been set,
         // in that case we assume the whole display frame.
-        frame = Rect(w, h);
+        char value[PROPERTY_VALUE_MAX];
+        property_get("ro.sf.hwrotation", value, "0");
+        int additionalRot = atoi(value);
+
+        if (additionalRot == 90 || additionalRot == 270)
+            frame = Rect(h, w);
+        else
+            frame = Rect(w, h);
     }
 
     if (viewport.isEmpty()) {


### PR DESCRIPTION
…0 or 270

Change-Id: I523204540ead9be61e5dc186fa6bbad7c468c3c4